### PR TITLE
Change stdinLn to stdinLn "in> " in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following code will continuously read inputs from the standard output, and e
 
     echo_example : IO ()
     echo_example = runEffect $
-      stdinLn                       -- Read the standard output
+      stdinLn "in> "                -- Read the standard output
         .| takingWhile (/= "quit")  -- Stop upon encountering "quit"
         .| mapping ("> " ++)        -- Add the prompt to the string
         .| stdoutLn                 -- Echo the string


### PR DESCRIPTION
It looks like `stdinLn` expects a `String` argument. To get the example to compile, I changed the code to be consistent with the code snippet in the blog post.